### PR TITLE
fix: update gitignore to exclude .key files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ logs/
 
 # Environment variables
 .env
+*.key
 
 # Build outputs
 dist/


### PR DESCRIPTION
Removing `.key` from `.gitignore` for kalshi api